### PR TITLE
Address rcl API change

### DIFF
--- a/rmw_microxrcedds_c/CMakeLists.txt
+++ b/rmw_microxrcedds_c/CMakeLists.txt
@@ -193,6 +193,7 @@ set(SRCS
   src/rmw_get_gid_for_client.c
   src/rmw_get_implementation_identifier.c
   src/rmw_get_serialization_format.c
+  src/rmw_get_service_endpoint_info.c
   src/rmw_get_topic_endpoint_info.c
   src/rmw_get_endpoint_network_flow.c
   src/rmw_qos_profile_check_compatible.c

--- a/rmw_microxrcedds_c/src/rmw_get_service_endpoint_info.c
+++ b/rmw_microxrcedds_c/src/rmw_get_service_endpoint_info.c
@@ -1,0 +1,54 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rmw/rmw.h>
+
+#include <rmw/get_service_endpoint_info.h>
+#include <rmw/types.h>
+
+#include "./rmw_microros_internal/error_handling_internal.h"
+
+rmw_ret_t
+rmw_get_clients_info_by_service(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * service_name,
+  bool no_mangle,
+  rmw_service_endpoint_info_array_t * clients_info)
+{
+  (void)node;
+  (void)allocator;
+  (void)service_name;
+  (void)no_mangle;
+  (void)clients_info;
+  RMW_UROS_TRACE_MESSAGE("function not implemented");
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_get_servers_info_by_service(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * service_name,
+  bool no_mangle,
+  rmw_service_endpoint_info_array_t * servers_info)
+{
+  (void)node;
+  (void)allocator;
+  (void)service_name;
+  (void)no_mangle;
+  (void)servers_info;
+  RMW_UROS_TRACE_MESSAGE("function not implemented");
+  return RMW_RET_UNSUPPORTED;
+}


### PR DESCRIPTION
## Description
This PR adds two new functions (whose implementation returns `RMW_RET_UNSUPPORTED`) to address the API change in `ros2/rcl` from https://github.com/ros2/rcl/pull/1161.

## Main changes
- Added a new file with the implementation of the functions
- Added a small change to `CMakeLists.txt` so that it accounts for the new file